### PR TITLE
feat: add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 [dependencies]
 atty = "0.2.14"
 lazy_static = "1.4.0"
+serde = { version = "1.0.123", optional = true, features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ lazy_static::lazy_static! {
 ///     - Unix systems have support if the active language supports them.
 ///     - Windows machines running the new Terminal app support emojis.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Emoji<'a, 'b>(pub &'a str, pub &'b str);
 
 impl<'a, 'b> Emoji<'a, 'b> {


### PR DESCRIPTION
(De)serialization can now be enabled via the `serde` feature flag.

Closes #5